### PR TITLE
correct flush name

### DIFF
--- a/documents_output/beamer/header_footer.tex
+++ b/documents_output/beamer/header_footer.tex
@@ -41,7 +41,7 @@ http://sparkandshine.net\\
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex]{palette quaternary}%
     	% Flush the bar to the left
     	\insertsectionnavigationhorizontal{\paperwidth}{}{\hskip0pt plus1filll}
-    	% Flush the bar to the left
+    	% Flush the bar to the right
     	%\insertsectionnavigationhorizontal{\paperwidth}{\hskip0pt plus1filll}{}
     	% Flush the bar to the center
     	%\insertsectionnavigationhorizontal{\paperwidth}{\hskip0pt plus1filll}{\hskip0pt plus1filll}


### PR DESCRIPTION
In the section used to add the table of content in the header the two first options were commented as "flush left" and only the first is indeed flushing the toc on the left, the second one is doing it on the right (I guess it was just a 'copy past' that was not corrected)